### PR TITLE
fix: optional params in trackCustomEvent

### DIFF
--- a/android/src/main/java/com/reactnativepiwikprosdk/PiwikProSdkModule.kt
+++ b/android/src/main/java/com/reactnativepiwikprosdk/PiwikProSdkModule.kt
@@ -68,10 +68,19 @@ class PiwikProSdkModule(reactContext: ReactApplicationContext) :
     try {
       val tracker = getTracker()
       val trackHelper = TrackHelper.track()
-      val customEventTracker = trackHelper.event(category, action).path(options?.getString("path"))
-        .name(options?.getString("name")).value(
-          options?.getDouble("value")?.toFloat()
-        )
+      val customEventTracker = trackHelper.event(category, action)
+
+      if (options?.hasKey("path") == true) {
+        customEventTracker.path(options.getString("path"))
+      }
+
+      if (options?.hasKey("name") == true) {
+        customEventTracker.name(options.getString("name"))
+      }
+
+      if (options?.hasKey("value") == true) {
+        customEventTracker.value(options.getDouble("value").toFloat())
+      }
 
       applyOptionalParameters(trackHelper, options)
       customEventTracker.with(tracker)


### PR DESCRIPTION
The **trackCustomEvent** function is throwing an error if _path_, _name_ or _value_ params are missing from the _options_ ReadableMap.

The [public API](https://github.com/PiwikPRO/react-native-piwik-pro-sdk/blob/master/src/index.d.tsx) for **trackCustomEvent** has _path_, _name_ and _value_ defined as optional params.

This change checks that the params are provided before trying to set them into the **customEventTracker** and fixes the issue.