### PR TITLE
fix: sendEventWithCategory missing path parameter

### DIFF
--- a/ios/PiwikProSdk.m
+++ b/ios/PiwikProSdk.m
@@ -65,7 +65,7 @@ RCT_REMAP_METHOD(trackCustomEvent,
     @try {
         [self applyOptionalParameters:options];
         
-        [[PiwikTracker sharedInstance] sendEventWithCategory:category action:action name:options[@"name"] value:options[@"value"]];
+        [[PiwikTracker sharedInstance] sendEventWithCategory:category action:action name:options[@"name"] value:options[@"value"] path:options[@"path"]];
         resolve(nil);
     } @catch (NSException *exception) {
         reject(exception.name, exception.reason, nil);


### PR DESCRIPTION
I was running into this error when building the latest version of the package on iOS:
`No visible @interface for 'PiwikTracker' declares the selector 'sendEventWithCategory:action:name:value:'`
So I added the `path` parameter to the `sendEventWithCategory` function in my local `PiwikProSdk.m` file and it seems to have fixed the issue.
I am not very good at Objective-C so I don't know if this is the right fix.
Hope this helps !