### PR TITLE
fix: added optional path variable to iOS bridge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Parameters:
 - `options` – custom event options, object containing five properties (all of them are optional):
   - `name: string` – label associated with the event. For example, if you have multiple button controls on a screen, you may use the label to specify the specific view control identifier that was clicked.
   - `value: number` – float, numerical value associated with the event. For example, if you were tracking 'Buy' button clicks, you may log the number of items being purchased or their total cost.
-  - `path: string` – the path under which this event occurred (it will be omitted in iOS application).
+  - `path: string` – the path under which this event occurred.
   - `customDimensions` – the object specifying [custom dimensions](#tracking-custom-dimensions).
   - `visitCustomVariables` – the object specifying [visit custom variables](#tracking-custom-variables).
 

--- a/ios/PiwikProSdk.m
+++ b/ios/PiwikProSdk.m
@@ -65,7 +65,7 @@ RCT_REMAP_METHOD(trackCustomEvent,
     @try {
         [self applyOptionalParameters:options];
         
-        [[PiwikTracker sharedInstance] sendEventWithCategory:category action:action name:options[@"name"] value:options[@"value"]];
+        [[PiwikTracker sharedInstance] sendEventWithCategory:category action:action name:options[@"name"] value:options[@"value"] path:options[@"path"]];
         resolve(nil);
     } @catch (NSException *exception) {
         reject(exception.name, exception.reason, nil);


### PR DESCRIPTION
The optional 'path' parameter added in the iOS PiwikPROSDK 1.1.5 ([Changelog](https://github.com/PiwikPRO/piwik-pro-sdk-framework-ios/blob/master/CHANGELOG.md)) broke the React Native SDK.

This pull request fixes the issue.