### PR TITLE
Export types correctly so they can be used in a typescript project

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,18 @@
 import { NativeModules } from 'react-native';
 import PiwikProSdk from '../';
+import type {
+  CommonEventOptions,
+  ProfileAttributes,
+  TrackCustomEventOptions,
+  TrackEcommerceOptions,
+  TrackGoalOptions,
+  TrackImpressionOptions,
+  TrackInteractionOptions,
+  TrackProfileAttributes,
+  TrackScreenOptions,
+  TrackSearchOptions,
+  TrackSocialInteractionOptions,
+} from '../types';
 
 const version = '0.0.1';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,24 @@
 import { NativeModules, Platform } from 'react-native';
+import type {
+  CommonEventOptions,
+  PiwikProSdkType,
+  ProfileAttributes,
+  TrackCustomEventOptions,
+  TrackEcommerceOptions,
+  TrackGoalOptions,
+  TrackImpressionOptions,
+  TrackInteractionOptions,
+  TrackProfileAttributes,
+  TrackScreenOptions,
+  TrackSocialInteractionOptions,
+} from './types';
+
 import {
-  validateInt,
   validateCustomKeyValue,
+  validateInt,
   validateVisitorId,
 } from './util/validator';
+
 import { version } from './version';
 
 const LINKING_ERROR =
@@ -299,5 +314,7 @@ const PiwikProSdk: PiwikProSdkType = {
   setPrefixing,
   isPrefixingOn,
 };
+
+export type { PiwikProSdkType } from './types';
 
 export default PiwikProSdk;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-type PiwikProSdkType = {
+export type PiwikProSdkType = {
   /**
    * Initializes Piwik Pro SDK. It's recommended to initialize
    * Piwik PRO SDK only once for the entire application.
@@ -87,7 +87,7 @@ type PiwikProSdkType = {
   /**
    * Tracks content interaction.
    * @contentName name of the content
-   * @interaction type of the interaction
+   * @interaction export type of the interaction
    * @options search tracking options (piece, target, customDimensions, visitCustomVariables)
    */
   trackInteraction(
@@ -269,57 +269,57 @@ type PiwikProSdkType = {
   isPrefixingOn(): Promise<boolean>;
 };
 
-type CustomDimensions = {
+export type CustomDimensions = {
   [index: number]: string;
 };
 
-type CustomVariable = {
+export type CustomVariable = {
   name: string;
   value: string;
 };
 
-type CustomVariables = {
+export type CustomVariables = {
   [index: number]: CustomVariable;
 };
 
-type CommonEventOptions = {
+export type CommonEventOptions = {
   customDimensions?: CustomDimensions;
   visitCustomVariables?: CustomVariables;
 };
 
-type TrackScreenOptions = CommonEventOptions & {
+export type TrackScreenOptions = CommonEventOptions & {
   title?: string;
   screenCustomVariables?: CustomVariables;
 };
 
-type TrackCustomEventOptions = CommonEventOptions & {
+export type TrackCustomEventOptions = CommonEventOptions & {
   name?: string;
   value?: number;
   path?: string;
 };
 
-type TrackSocialInteractionOptions = CommonEventOptions & {};
+export type TrackSocialInteractionOptions = CommonEventOptions & {};
 
-type TrackSearchOptions = CommonEventOptions & {
+export type TrackSearchOptions = CommonEventOptions & {
   category?: string;
   count?: number;
 };
 
-type TrackImpressionOptions = CommonEventOptions & {
+export type TrackImpressionOptions = CommonEventOptions & {
   piece?: string;
   target?: string;
 };
 
-type TrackInteractionOptions = CommonEventOptions & {
+export type TrackInteractionOptions = CommonEventOptions & {
   piece?: string;
   target?: string;
 };
 
-type TrackGoalOptions = CommonEventOptions & {
+export type TrackGoalOptions = CommonEventOptions & {
   revenue?: number;
 };
 
-type EcommerceItem = {
+export type EcommerceItem = {
   sku: string;
   name: string;
   category: string;
@@ -327,7 +327,7 @@ type EcommerceItem = {
   quantity: number;
 };
 
-type TrackEcommerceOptions = CommonEventOptions & {
+export type TrackEcommerceOptions = CommonEventOptions & {
   subTotal?: number;
   tax?: number;
   shipping?: number;
@@ -335,13 +335,13 @@ type TrackEcommerceOptions = CommonEventOptions & {
   items?: EcommerceItem[];
 };
 
-type ProfileAttributes = {
+export type ProfileAttributes = {
   [index: string]: string;
 };
 
-type TrackProfileAttribute = {
+export type TrackProfileAttribute = {
   name: string;
   value: string;
 };
 
-type TrackProfileAttributes = TrackProfileAttribute | TrackProfileAttribute[];
+export type TrackProfileAttributes = TrackProfileAttribute | TrackProfileAttribute[];

--- a/src/util/validator.ts
+++ b/src/util/validator.ts
@@ -1,3 +1,5 @@
+import type { CustomDimensions, CustomVariables } from '../types';
+
 function validateInt(value: number) {
   if (!Number.isInteger(value)) {
     throw new Error('Parameter must be an integer number');


### PR DESCRIPTION
The types are currently not exported correctly. There is also an open issue for this https://github.com/PiwikPRO/react-native-piwik-pro-sdk/issues/55.

- Changed `.tsx` files to normal `.ts` files. No JSX is exported, so no need for `tsx`.
- Moved from `index.d.ts` to `types.ts` so they can be imported in the needed files.