### PR TITLE
Fix trackSearch typing

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,7 @@ export type PiwikProSdkType = {
    * @keyword searched query that was used in the app
    * @options search tracking options (category, count, customDimensions, visitCustomVariables)
    */
-  trackSearch(keyword: string, options?: TrackScreenOptions): Promise<void>;
+  trackSearch(keyword: string, options?: TrackSearchOptions): Promise<void>;
 
   /**
    * Tracks content impression.


### PR DESCRIPTION
The typing of the options of trackSearch should be `TrackSearchOptions` and not `TrackScreenOptions`